### PR TITLE
match outline

### DIFF
--- a/wall.css
+++ b/wall.css
@@ -8,6 +8,7 @@
 }
 
 :focus {
+  outline-color: currentColor;
   outline-style: dashed;
   outline-width: thick;
 }


### PR DESCRIPTION
FF already matched but Chrome was blueish.

`currentColor` is ideal when there are no deep backgrounds 

```css
outline-color: currentColor;
```